### PR TITLE
🧪🐧 ↝ Initial use of habanero to retrieve paper information from CrossRef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Virtual environment folders
+venv

--- a/Publication Text Extraction - Henry/main.py
+++ b/Publication Text Extraction - Henry/main.py
@@ -1,21 +1,46 @@
 """
 Script for extracting machine readable text from a web publication/paper which
 needs to be downloaded
-Adapted from Wang et. al. 2022 10.1038/s41524-021-00687-2
+Adapted from the process described by Wang et. al. 2022 10.1038/s41524-021-00687-2
 
 Crossref API info: https://api.crossref.org/swagger-ui/index.html
 
 habanero package info: https://pypi.org/project/habanero/
-
 """
 import time  # for using time.sleep() if needing to pause data requests
 from habanero import Crossref
+from habanero import cn
 
 
 cr = Crossref()
 
-# query
-x = cr.works(query = "ecology")
-x['message']
-x['message']['total-results']
-x['message']['items']
+# Setting info for mailto for contact email and user-agent for description of use case
+# For attempts to get into the 'polite pool' for paper requests through the API
+cr.mailto = 'haloh@mix.wvu.edu'
+cr.ua_string = 'Python script for retrieving paper info from query for research.'
+
+# query section, request results based on a search
+# cursor='*' alloy 'deep paging' (according to function documentation in crossref.py)
+# cursor_max sets the max number of records to retrieve, by default it's 20 I think
+# seems to do max results returned from deep paging in sets of 20, e.g. a request of 15 still gives 20
+n = 2  # multiple of 20 for deep paging
+request = cr.works(query = "Automated pipeline for superalloy data by text mining", cursor='*', cursor_max=n*20, progress_bar=True)  # test query searching for papers based on a string
+
+allowed_types = ['proceedings-article', 'book-chapter', 'dissertation', 'journal-article']  # specifying document types of parse
+# print the title and the type of item from the results
+for i in range(n):
+    for j in range(len(request[i]['message']['items'])):
+        if request[i]['message']['items'][j]['type'] not in allowed_types:  # skipping if not a type wanted
+            continue
+        title = request[i]['message']['items'][j]['title'][0]
+        type = request[i]['message']['items'][j]['type']
+        print(f'{title}, {type}')  # print the title and type of each results
+        time.sleep(0.25)  # sleep between prints so it's not too fast
+
+
+request_doi = cr.works(ids = '10.1038/s41524-021-00687-2')  # search for a specific paper using a DOI number
+print(request_doi['message']['title'][0])
+citation = cn.content_negotiation(ids = '10.1038/s41524-021-00687-2', format = 'text')  # get citation for the DOI
+print(citation)
+
+pass

--- a/Publication Text Extraction - Henry/main.py
+++ b/Publication Text Extraction - Henry/main.py
@@ -42,5 +42,3 @@ request_doi = cr.works(ids = '10.1038/s41524-021-00687-2')  # search for a speci
 print(request_doi['message']['title'][0])
 citation = cn.content_negotiation(ids = '10.1038/s41524-021-00687-2', format = 'text')  # get citation for the DOI
 print(citation)
-
-pass

--- a/Publication Text Extraction - Henry/main.py
+++ b/Publication Text Extraction - Henry/main.py
@@ -1,0 +1,21 @@
+"""
+Script for extracting machine readable text from a web publication/paper which
+needs to be downloaded
+Adapted from Wang et. al. 2022 10.1038/s41524-021-00687-2
+
+Crossref API info: https://api.crossref.org/swagger-ui/index.html
+
+habanero package info: https://pypi.org/project/habanero/
+
+"""
+import time  # for using time.sleep() if needing to pause data requests
+from habanero import Crossref
+
+
+cr = Crossref()
+
+# query
+x = cr.works(query = "ecology")
+x['message']
+x['message']['total-results']
+x['message']['items']

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The core of this project is to see how we can use LLM and other technology avail
 2. Metadata is inconsistently applied.
 3. Metadata is inflexible
 
-These features create a problem which makes relevant literature difficult to connect to eachother, leaves the decision of what metadata to include up to researchers or journals, and requries standard application to be useful. We then end up with inconsistent metadata that can't connect research projects either to their own research objects like the code and data associated with them, or to other papers that might be relevant. These issues make academic search and representing an accurate 'map' of science extremely difficult. 
+These features create a problem which makes relevant literature difficult to connect to each other, leaves the decision of what metadata to include up to researchers or journals, and requires standard application to be useful. We then end up with inconsistent metadata that can't connect research projects either to their own research objects like the code and data associated with them, or to other papers that might be relevant. These issues make academic search and representing an accurate 'map' of science extremely difficult. 
 
 We hope to see how we can create a flexible metadata standard that accurately connects papers both to their own additional materials and to other research based on as much data as we can gather. 
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ We hope to see how we can create a flexible metadata standard that accurately co
 We're operationalizing this problem as: 
 
 How might we reliably automate a literature review? 
+
+
+## Publication Text Extraction
+### Aim/Goal
+The aim/goal of this is to provide a way to programmically extract machine readable text from journal publication when provided an identifier such as a title or DOI.
+Adapted using the methodology described in https://www.nature.com/articles/s41524-021-00687-2, "Automated pipeline for superalloy data by text mining"
+
+### Installation

--- a/README.md
+++ b/README.md
@@ -22,4 +22,9 @@ How might we reliably automate a literature review?
 The aim/goal of this is to provide a way to programmically extract machine readable text from journal publication when provided an identifier such as a title or DOI.
 Adapted using the methodology described in https://www.nature.com/articles/s41524-021-00687-2, "Automated pipeline for superalloy data by text mining"
 
-### Installation
+### Setup and use
+Requires the habanero python package for searching crossref (https://pypi.org/project/habanero/)
+
+```shell
+pip install habanero
+```


### PR DESCRIPTION
Modified the README to fix a few spelling changes as well as added a section describing the purpose of the code in the 'Publication Text Extraction - Henry' folder.

Put together an initial python script for using the habanero package which searches Crossref for entries based on a search criteria and returns the results. Mainly was able to set up searching for a handful of papers based on a search query, e.g. keywords, paper title, and access item details such as the name of the item and what type of data it is (e.g. journal paper, book chapter, etc.).

Also included an example of use for extracting the citation information for a paper given the DOI.

All in all, this should allow the retrieval of some metadata information values for a paper based on search terms or a specific DOI lookup.